### PR TITLE
Update package lib to preview.2 and change accordingly

### DIFF
--- a/NuGet/NuGet.csproj
+++ b/NuGet/NuGet.csproj
@@ -7,6 +7,7 @@
 		<Nullable>enable</Nullable>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>mcp-server-nuget</ToolCommandName>
+		<!--<PublishAot>True</PublishAot>-->
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -17,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-		<PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.1.25171.12" />
+		<PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.2" />
 		<PackageReference Include="NuGet.Protocol" Version="6.13.2" />
 	</ItemGroup>
 

--- a/NuGet/NuGetTools.cs
+++ b/NuGet/NuGetTools.cs
@@ -8,7 +8,7 @@ using ModelContextProtocol.Server;
 
 namespace NetMcp.NuGet;
 
-[McpToolType]
+[McpServerToolType]
 public partial class NuGetTools
 {
     /// <summary>
@@ -16,7 +16,7 @@ public partial class NuGetTools
     /// </summary>
     public const string DefaultNuGetSource = "https://api.nuget.org/v3/index.json";
 
-    [McpTool("nuget_search")]
+    [McpServerTool("nuget_search")]
     [Description(NuGetSearchDescription)]
     public static async Task<string> SearchPackagesAsync(
         [Description(NuGetSearchQueryDescription)]

--- a/NuGet/Program.cs
+++ b/NuGet/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddMcpServer()
     .WithReadResourceHandler(NuGetResources.ReadResourceHandler)
     //.WithHttpListenerSseServerTransport()
 	.WithStdioServerTransport()
-    .WithTools();
+    .WithTools<NuGetTools>();
 
 builder.Logging.ClearProviders();
 


### PR DESCRIPTION
Update package lib to preview.2 and change accordingly

#### PR Classification
Update to package versions and tool type designations for improved functionality.

#### PR Summary
This pull request updates the `ModelContextProtocol` package version and modifies tool type attributes for better integration. Key changes include:
- `NuGet.csproj`: Updated `ModelContextProtocol` version to `0.1.0-preview.2` .
- `NuGetTools.cs`: Replaced `[McpToolType]` with `[McpServerToolType]` for the `SearchPackagesAsync` method.
- `Program.cs`: Changed `.WithTools()` to `.WithTools<NuGetTools>()` for enhanced type safety.
